### PR TITLE
removed extra '}' from SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -29,7 +29,7 @@ if env["target"] in ["editor", "template_debug"]:
 
 if env["platform"] == "macos":
     library = env.SharedLibrary(
-        bin_folder + "{}.{}.{}.framework/{}}.{}.{}".format(
+        bin_folder + "{}.{}.{}.framework/{}.{}.{}".format(
             lib_name, env["platform"], env["target"], lib_name, env["platform"], env["target"]
         ),
         source=sources,


### PR DESCRIPTION
running scons was erroring out with "ValueError: Single '}' encountered in format string", this line is apparently why